### PR TITLE
Fix tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -80,9 +80,16 @@
 
         <dependency>
             <groupId>org.mock-server</groupId>
-            <artifactId>mockserver-netty</artifactId>
-            <version>5.10.0</version>
+            <artifactId>mockserver-junit-rule</artifactId>
+            <version>5.11.1</version>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>1.6.1</version>
+        </dependency>
+
     </dependencies>
 </project>

--- a/src/test/java/org/privacyidea/TestWebAuthn.java
+++ b/src/test/java/org/privacyidea/TestWebAuthn.java
@@ -17,6 +17,7 @@ package org.privacyidea;
 
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.After;
 import org.mockserver.integration.ClientAndServer;
 import org.mockserver.model.HttpRequest;
 import org.mockserver.model.HttpResponse;
@@ -39,6 +40,11 @@ public class TestWebAuthn implements IPILogger {
                 .setSSLVerify(false)
                 .setLogger(this)
                 .build();
+    }
+
+    @After
+    public void teardown() {
+        mockServer.stop();
     }
 
     @Test


### PR DESCRIPTION
* Adjust pom.xml to include dependency org.slf4j
* Added mockserver.stop() during WebAuthn testcase, was causing 'port already in use error' during all tests run
* upgraded to recent version of mockserver dependency